### PR TITLE
feat: docgen implementation as command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -216,9 +216,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "cw-swaggy"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e16cf527ca933ecf50fdf748bd2aeaad5c35ab1c0b7d3148952510a9a89539"
+checksum = "fe72c66600af1943b533f9e0f329e95aafce2468146133e6e58946359af1761d"
 dependencies = [
  "axum",
  "clap",
@@ -246,6 +246,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
  "toml",
 ]
 
@@ -912,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ thiserror = "2.0.12"
 regex = { version = "1.11.1", default-features = false, features = ["std", "perf"] }
 rpassword = "7.4.0"
 owo-colors = "4.2.2"
-cw-swaggy = "0.1"
+cw-swaggy = "0.1.4"
+tokio = { version = "1.47.1", features = ["full"] }
 
 
 [[bin]]

--- a/src/commands/autodeploy.rs
+++ b/src/commands/autodeploy.rs
@@ -21,7 +21,7 @@ pub struct AutoDeployCommand {
 }
 
 impl Executable for AutoDeployCommand {
-    fn execute(
+    async fn execute(
         &self,
         project_root: Option<PathBuf>,
         config: Option<ProjectConfig>,
@@ -56,7 +56,7 @@ impl Executable for AutoDeployCommand {
                 Some(project_root),
                 Some(config.clone()),
                 profile,
-            )?;
+            ).await?;
         }
 
         let deployment_account = profile

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -15,7 +15,7 @@ pub struct BuildCommand {
 }
 
 impl Executable for BuildCommand {
-    fn execute(
+    async fn execute(
         &self,
         project_root: Option<PathBuf>,
         config: Option<ProjectConfig>,

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -54,7 +54,7 @@ pub enum NetworkConfig {
 }
 
 impl Executable for ConfigCommand {
-    fn execute(
+    async fn execute(
         &self,
         project_root: Option<PathBuf>,
         config: Option<ProjectConfig>,

--- a/src/commands/docgen.rs
+++ b/src/commands/docgen.rs
@@ -3,7 +3,11 @@ use cw_swaggy::executable::{Executable as SwaggyExecutable, ExecutionContext};
 
 
 #[derive(clap::Args, Debug, Clone, PartialEq, Eq)]
-pub struct DocgenCommand {}
+pub struct DocgenCommand {
+    /// Do not serve the generated documentation
+    #[clap(long, default_value_t = false)]
+    pub no_serve: bool,
+}
 
 impl Executable for DocgenCommand {
     async fn execute(
@@ -32,6 +36,9 @@ impl Executable for DocgenCommand {
             .map_err(|e| crate::error::WarpError::DocgenError(e.to_string()))?;
         
         // 3. Docgen execution - serve
+        if self.no_serve {
+            return Ok(());
+        }
         cw_swaggy::commands::serve::ServeCmd {
             schema: root_path.join("openapi.json"),
             port: 8008,

--- a/src/commands/docgen.rs
+++ b/src/commands/docgen.rs
@@ -1,0 +1,45 @@
+use crate::{commands::schema::SchemaCommand, executable::Executable};
+use cw_swaggy::executable::{Executable as SwaggyExecutable, ExecutionContext};
+
+
+#[derive(clap::Args, Debug, Clone, PartialEq, Eq)]
+pub struct DocgenCommand {}
+
+impl Executable for DocgenCommand {
+    async fn execute(
+        &self,
+        project_root: Option<std::path::PathBuf>,
+        config: Option<crate::utils::project_config::ProjectConfig>,
+        profile: &Box<dyn crate::chains::chain_profile::ChainProfile>,
+    ) -> Result<(), crate::error::WarpError> {
+        // Placeholder for documentation generation logic
+        println!("Generating documentation...");
+        let root_path = project_root.unwrap();
+        // 1. Schema generation
+        SchemaCommand { 
+
+        }.execute(Some(root_path.clone()), config, profile).await?;
+
+
+        // 2. Docgen execution - build
+        let ctx = ExecutionContext::try_load();
+        let ctx = ctx.map_err(|e| crate::error::WarpError::DocgenError(e.to_string()))?;
+        cw_swaggy::commands::build::BuildCmd {
+            schema: root_path.join("schema"),
+        }
+            .execute(&ctx)
+            .await
+            .map_err(|e| crate::error::WarpError::DocgenError(e.to_string()))?;
+        
+        // 3. Docgen execution - serve
+        cw_swaggy::commands::serve::ServeCmd {
+            schema: root_path.join("openapi.json"),
+            port: 8008,
+            wasm: None,
+        }
+        .execute(&ctx)
+        .await
+        .map_err(|e| crate::error::WarpError::DocgenError(e.to_string()))?;
+        Ok(())
+    }
+}

--- a/src/commands/frontend.rs
+++ b/src/commands/frontend.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 pub struct FrontendCommand {}
 
 impl Executable for FrontendCommand {
-    fn execute(
+    async fn execute(
         &self,
         project_root: Option<PathBuf>,
         config: Option<ProjectConfig>,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -40,7 +40,7 @@ impl ChainParam {
 }
 
 impl Executable for InitCommand {
-    fn execute(
+    async fn execute(
         &self,
         _project_root: Option<PathBuf>,
         _config: Option<ProjectConfig>,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,5 +8,6 @@ pub mod config;
 pub mod wasm;
 pub mod frontend;
 pub mod schema;
+pub mod docgen;
 
 pub use build::*;

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -20,7 +20,7 @@ pub struct NewCommand {
 }
 
 impl Executable for NewCommand {
-    fn execute(
+    async fn execute(
         &self,
         project_root: Option<PathBuf>,
         config: Option<ProjectConfig>,

--- a/src/commands/node.rs
+++ b/src/commands/node.rs
@@ -17,7 +17,7 @@ pub struct NodeCommand {
 }
 
 impl Executable for NodeCommand {
-    fn execute(
+    async fn execute(
         &self,
         project_root: Option<PathBuf>,
         config: Option<ProjectConfig>,

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -12,7 +12,7 @@ use crate::{
 pub struct SchemaCommand {}
 
 impl Executable for SchemaCommand {
-    fn execute(
+    async fn execute(
         &self,
         project_root: Option<PathBuf>,
         _config: Option<ProjectConfig>,

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -20,7 +20,7 @@ pub struct TestCommand {
 }
 
 impl Executable for TestCommand {
-    fn execute(
+    async fn execute(
         &self,
         project_root: Option<PathBuf>,
         config: Option<ProjectConfig>,
@@ -35,7 +35,7 @@ impl Executable for TestCommand {
         // 1. Build the code if requested
         if self.rebuild {
             let cmd = BuildCommand { optimized: true };
-            cmd.execute(Some(project_root.clone()), Some(config.clone()), profile)?;
+            cmd.execute(Some(project_root.clone()), Some(config.clone()), profile).await?;
         }
 
         // 2. Set up the node unless specified otherwise
@@ -46,7 +46,7 @@ impl Executable for TestCommand {
                 container: Some(config.tests.test_container_name.clone()),
                 persistant: config.tests.persist_image,
             };
-            let status = cmd.execute(Some(project_root.clone()), Some(config.clone()), profile);
+            let status = cmd.execute(Some(project_root.clone()), Some(config.clone()), profile).await;
             let is_conflict = match status {
                 Ok(_) => false,
                 Err(x) => {

--- a/src/commands/wasm.rs
+++ b/src/commands/wasm.rs
@@ -52,7 +52,7 @@ pub struct WasmQueryArgs {
 }
 
 impl Executable for WasmCommand {
-    fn execute(
+    async fn execute(
         &self,
         project_root: Option<PathBuf>,
         config: Option<ProjectConfig>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,4 +38,6 @@ pub enum WarpError {
     ContractIdNotFound(String),
     #[error("Schema generation failed for contract '{0}': {1}")]
     SchemaGenerationFailed(String, String),
+    #[error("DocGen Error: {0}")]
+    DocgenError(String),
 }

--- a/src/executable.rs
+++ b/src/executable.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 
 pub trait Executable {
-    fn execute(
+    async fn execute(
         &self,
         project_root: Option<std::path::PathBuf>,
         config: Option<ProjectConfig>,


### PR DESCRIPTION
This pull request refactors the command execution framework to be fully asynchronous, introduces a new `docgen` command for documentation generation, and updates dependencies to support async execution. The changes improve scalability and enable non-blocking operations for all commands, while also adding new functionality for generating and serving documentation.

### Async command execution

* Refactored the `Executable` trait and all command structs (`AutoDeployCommand`, `BuildCommand`, `ConfigCommand`, `FrontendCommand`, `InitCommand`, `NewCommand`, `NodeCommand`, `SchemaCommand`, `TestCommand`, `WasmCommand`) to use `async fn execute`, making all command executions asynchronous. Updated all internal command calls to use `.await`. [[1]](diffhunk://#diff-1ef589cdcca064eb912c7081819f0ae03723d01dcfd7651416c456116dfe7227L24-R24) [[2]](diffhunk://#diff-fecf70788e2f7552a6c0aa836593643a36d5da2acbeb4e0aad343103218668d9L18-R18) [[3]](diffhunk://#diff-0f0dc759b584bcbecbadd0bcd8c780a33e726fd8f6e491763febbaf92668d7c4L57-R57) [[4]](diffhunk://#diff-00008117cb71ee2c738c3a00e2e45b6267af94920892a5a5f7ed7b20789434ccL13-R13) [[5]](diffhunk://#diff-cadd09612a7d662d0ed12de2a0c70dc7afbea48e3aa5861398fea744dc49f476L43-R43) [[6]](diffhunk://#diff-696291dc3c8d5ad14f43a137b08b142f491b34cb84736d26c9491fc394267f0aL23-R23) [[7]](diffhunk://#diff-161d59790c7d9e7d5ece846881e38141f36917f4b38678b82b93eb6b8bc6571dL20-R20) [[8]](diffhunk://#diff-6fd32f345f984c709ba7f4c54c044f571f944bbf58782ae9108cf948613fcf46L15-R15) [[9]](diffhunk://#diff-5bff03b2a34c227ec0cd14e7c890bbfe3c19409d614c88f27a4aba218c425a80L23-R23) [[10]](diffhunk://#diff-a2a08048568c9ac2795028bebacd98cb0bc358069ca6fe94257be7082a2c86d6L55-R55) [[11]](diffhunk://#diff-fcadf0ebce9fd59f176490e7992bf6342f6b1f27a4c6a4d4f464f08e05aa2808L6-R6) [[12]](diffhunk://#diff-5bff03b2a34c227ec0cd14e7c890bbfe3c19409d614c88f27a4aba218c425a80L38-R38) [[13]](diffhunk://#diff-5bff03b2a34c227ec0cd14e7c890bbfe3c19409d614c88f27a4aba218c425a80L49-R49)

* Updated the main entry point to use the `tokio` runtime (`#[tokio::main]`), allowing async execution of commands in the CLI. All command dispatches in `main.rs` now use `.await`. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL55-R58) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL86-R103)

### New documentation generation command

* Added a new `DocgenCommand` in `src/commands/docgen.rs`, which generates documentation by running schema generation, building documentation assets, and serving them via the `cw_swaggy` library. Integrated this command into the CLI and main dispatch logic. [[1]](diffhunk://#diff-a7df53503e8414a99dca669d6e149b6dc43d27da4758a807e89841da9f7f13e2R1-R45) [[2]](diffhunk://#diff-bf2f650cdc66abd13076c47b25e8c9f783f06ec335bbd30822fdd690547615fdR11) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL21-R21) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR41-R42) [[5]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL86-R103)

### Dependency updates

* Updated `cw-swaggy` to version `0.1.4` and added `tokio` as a dependency with full features to support async operations.

### Error handling improvements

* Added a new error variant `DocgenError` to `WarpError` for better error reporting in documentation generation flows.

---

These changes modernize the command execution model, improve error handling, and add a new feature for documentation generation, making the CLI more robust and extensible.